### PR TITLE
 Fix crash when MimeType cannot be determined.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.4
+
+* Fix crash when MimeType cannot be determined.   
+(It could not be retrieved from the file name due to a simple mistake)
+
 ## 0.13.3
 
 * Fix crash when MimeType cannot be determined.

--- a/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
@@ -219,7 +219,7 @@ class ImageDownloaderPlugin(
 
                 file.renameTo(newFile)
                 val newMimeType = mimeType
-                    ?: MimeTypeMap.getSingleton().getMimeTypeFromExtension(file.extension) ?: ""
+                    ?: MimeTypeMap.getSingleton().getMimeTypeFromExtension(newFile.extension) ?: ""
                 val imageId = saveToDatabase(newFile, newMimeType, inPublicDir)
 
                 result.success(imageId)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: image_downloader
 description: Flutter plugin that downloads images on the Internet and saves them on device.
-version: 0.13.3
+version: 0.13.4
 authors:
 - koji ishii <ko2ic.dev@gmail.com>
 homepage: https://github.com/ko2ic/image_downloader


### PR DESCRIPTION
It could not be retrieved from the file name due to a simple mistake.