### PR TITLE
Remove -undefined dynamic_lookup in .podspec

### DIFF
--- a/ios/image_downloader.podspec
+++ b/ios/image_downloader.podspec
@@ -17,7 +17,7 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.pod_target_xcconfig = {
    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
+   'OTHER_LDFLAGS' => '$(inherited)'
   }
   s.ios.deployment_target = '8.0'
   s.swift_version = '4.2'


### PR DESCRIPTION
## Remove -undefined dynamic_lookup in .podspec 

- issue : `ENABLE_BITCODE = YES;` => error 
```bash
error: -undefined and -bitcode_bundle (Xcode setting ENABLE_BITCODE=YES) cannot be used 
together
```
- Support bitcode

--------------------

Hello @ko2ic,
Recently, `flutter sdk` supports bitcode (iOS) https://github.com/flutter/flutter/pull/46204
But this plugin is not supported.
May I request a review?
Thanks.
