### PR TITLE
Fixed to work on example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ Add the following keys to your Info.plist file, located in <project root>/ios/Ru
 
 ### Android
 
-Add this permission in ```AndroidManifest.xml```. (If you call ```AndroidDestinationType#inExternalFilesDir()```, This setting is not necessary.)
+Add these permissions in ```AndroidManifest.xml```. 
 
 ```xml
+<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+<uses-permission android:name="android.permission.INTERNET" />
+
+<!-- If your application only targets API level 33 and above, this is not necessary -->
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 ```
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPermissionListener.kt
+++ b/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPermissionListener.kt
@@ -20,7 +20,7 @@ class ImageDownloaderPermissionListener(private val activity: Activity) :
         private val STORAGE_PERMISSIONS = arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
 
         @TargetApi(Build.VERSION_CODES.TIRAMISU)
-        private val STORAGE_PERMISSIONS_TIRAMISU = arrayOf(Manifest.permission.READ_MEDIA_IMAGES)
+        private val STORAGE_PERMISSIONS_TIRAMISU = arrayOf(Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO)
     }
 
     override fun onRequestPermissionsResult(

--- a/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPermissionListener.kt
+++ b/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPermissionListener.kt
@@ -1,8 +1,10 @@
 package com.ko2ic.imagedownloader
 
 import android.Manifest
+import android.annotation.TargetApi
 import android.app.Activity
 import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import io.flutter.plugin.common.PluginRegistry
@@ -13,6 +15,13 @@ class ImageDownloaderPermissionListener(private val activity: Activity) :
     private val permissionRequestId: Int = 2578166
 
     var callback: Callback? = null
+
+    companion object {
+        private val STORAGE_PERMISSIONS = arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+
+        @TargetApi(Build.VERSION_CODES.TIRAMISU)
+        private val STORAGE_PERMISSIONS_TIRAMISU = arrayOf(Manifest.permission.READ_MEDIA_IMAGES)
+    }
 
     override fun onRequestPermissionsResult(
         requestCode: Int, permissions: Array<String>, grantResults: IntArray
@@ -37,7 +46,11 @@ class ImageDownloaderPermissionListener(private val activity: Activity) :
     }
 
     fun alreadyGranted(): Boolean {
-        val permissions = arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            STORAGE_PERMISSIONS_TIRAMISU
+        } else {
+            STORAGE_PERMISSIONS
+        }
 
         if (!isPermissionGranted(permissions)) {
             // Request authorization. User is not yet authorized.

--- a/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
@@ -408,8 +408,6 @@ class ImageDownloaderPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                         .getMimeTypeFromExtension(newFile.extension) ?: ""
                     val imageId = saveToDatabase(newFile, mimeType ?: newMimeType, inPublicDir)
 
-                    Log.d("ImageId", "image id: $imageId")
-
                     result.success(imageId)
                 }
             })

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -47,5 +47,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app uses photo library to save image from internet.</string>
 </dict>
 </plist>

--- a/ios/Classes/SwiftImageDownloaderPlugin.swift
+++ b/ios/Classes/SwiftImageDownloaderPlugin.swift
@@ -81,7 +81,8 @@ public class SwiftImageDownloaderPlugin: NSObject, FlutterPlugin {
     }
 
     private func setData(_ call: FlutterMethodCall, result: @escaping FlutterResult, completion: (String) -> Void) {
-        guard let imageId = (call.arguments as? Dictionary<String, String>)?["imageId"] else {
+        guard let args = call.arguments as? Dictionary<String, Any>,
+            let imageId = args["imageId"] as? String else {
             result(FlutterError(code: "assertion_error", message: "imageId is required.", details: nil))
             return
         }

--- a/lib/image_downloader.dart
+++ b/lib/image_downloader.dart
@@ -61,23 +61,27 @@ class ImageDownloader {
   }
 
   /// Acquire the saved image name.
-  static Future<String?> findName(String imageId) async {
-    return _channel.invokeMethod<String>('findName', {'imageId': imageId});
+  /// The argument [isVideo] is not required. However, providing it may improve performance. (especially when querying for video).
+  static Future<String?> findName(String imageId, { bool? isVideo }) async {
+    return _channel.invokeMethod<String>('findName', {'imageId': imageId, 'isVideo': isVideo});
   }
 
   /// Acquire the saved image path.
-  static Future<String?> findPath(String imageId) async {
-    return _channel.invokeMethod<String>('findPath', {'imageId': imageId});
+  /// The argument [isVideo] is not required. However, providing it may improve performance. (especially when querying for video).
+  static Future<String?> findPath(String imageId, { bool? isVideo }) async {
+    return _channel.invokeMethod<String>('findPath', {'imageId': imageId, 'isVideo': isVideo});
   }
 
   /// Acquire the saved image byte size.
-  static Future<int?> findByteSize(String imageId) async {
-    return _channel.invokeMethod<int>('findByteSize', {'imageId': imageId});
+  /// The argument [isVideo] is not required. However, providing it may improve performance. (especially when querying for video).
+  static Future<int?> findByteSize(String imageId, { bool? isVideo }) async {
+    return _channel.invokeMethod<int>('findByteSize', {'imageId': imageId, 'isVideo': isVideo});
   }
 
   /// Acquire the saved image mimeType.
-  static Future<String?> findMimeType(String imageId) async {
-    return _channel.invokeMethod<String>('findMimeType', {'imageId': imageId});
+  /// The argument [isVideo] is not required. However, providing it may improve performance. (especially when querying for video).
+  static Future<String?> findMimeType(String imageId, { bool? isVideo }) async {
+    return _channel.invokeMethod<String>('findMimeType', {'imageId': imageId, 'isVideo': isVideo});
   }
 }
 


### PR DESCRIPTION
## Description
- Fixed to request correct permissions on Android 13.
- Fixed to determine if it is a video by mimeType and save the videos and photos in the correct location.
- Added optional parameter `isVideo` to `findName`, `findPath`, `findByteSize` and `findMimeType`.
  - It is used for querying media file on Android.
  - If it is not provided, the video is queried after searching the photo library.