### PR TITLE
Add success case (ImageDownloaderPlugin.kt)

### DIFF
--- a/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
@@ -320,6 +320,7 @@ class ImageDownloaderPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             downloader.execute(onNext = {
                 Log.d(LOGGER_TAG, it.result.toString())
                 when (it) {
+                    is Downloader.DownloadStatus.Successful -> Log.d(LOGGER_TAG, it.reason)
                     is Downloader.DownloadStatus.Failed -> Log.d(LOGGER_TAG, it.reason)
                     is Downloader.DownloadStatus.Paused -> Log.d(LOGGER_TAG, it.reason)
                     is Downloader.DownloadStatus.Running -> {

--- a/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
@@ -320,7 +320,7 @@ class ImageDownloaderPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             downloader.execute(onNext = {
                 Log.d(LOGGER_TAG, it.result.toString())
                 when (it) {
-                    is Downloader.DownloadStatus.Successful -> Log.d(LOGGER_TAG, it.reason)
+                    is Downloader.DownloadStatus.Successful -> Log.d(LOGGER_TAG, "Successful")
                     is Downloader.DownloadStatus.Failed -> Log.d(LOGGER_TAG, it.reason)
                     is Downloader.DownloadStatus.Paused -> Log.d(LOGGER_TAG, it.reason)
                     is Downloader.DownloadStatus.Running -> {

--- a/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
@@ -320,7 +320,7 @@ class ImageDownloaderPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
             downloader.execute(onNext = {
                 Log.d(LOGGER_TAG, it.result.toString())
                 when (it) {
-                    is Downloader.DownloadStatus.Successful -> Log.d(LOGGER_TAG, "Successful")
+                    is Downloader.DownloadStatus.Successful -> {}
                     is Downloader.DownloadStatus.Failed -> Log.d(LOGGER_TAG, it.reason)
                     is Downloader.DownloadStatus.Paused -> Log.d(LOGGER_TAG, it.reason)
                     is Downloader.DownloadStatus.Running -> {


### PR DESCRIPTION
now doesn't throw AssertionError on newer versions of Kotlin