### PR TITLE
bug on latest android sdk : 'when' expression must be exhaustive, add necessary 'is Pending'…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.ko2ic.imagedownloader'
     compileSdkVersion 33
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,10 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+     compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
     kotlinOptions {
         jvmTarget = '1.8'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,10 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
 }
 
 dependencies {

--- a/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
+++ b/android/src/main/kotlin/com/ko2ic/imagedownloader/ImageDownloaderPlugin.kt
@@ -322,6 +322,10 @@ class ImageDownloaderPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 when (it) {
                     is Downloader.DownloadStatus.Failed -> Log.d(LOGGER_TAG, it.reason)
                     is Downloader.DownloadStatus.Paused -> Log.d(LOGGER_TAG, it.reason)
+                    // fix error
+                    // 'when' expression must be exhaustive, add necessary 'is Pending', 'is Successful' branches or 'else' branch instead
+                    is Downloader.DownloadStatus.Successful -> Log.d(LOGGER_TAG, "Successful")
+                    is Downloader.DownloadStatus.Pending -> Log.d(LOGGER_TAG, "Pending")
                     is Downloader.DownloadStatus.Running -> {
                         Log.d(LOGGER_TAG, it.progress.toString())
                         val args = HashMap<String, Any>()


### PR DESCRIPTION
 error 'when' expression must be exhaustive, add necessary 'is Pending', 'is Successful' branches or 'else' branch instead
 
 everybody can temp fix by:

```
 change  `image_downloader: ^0.31.0` to
  image_downloader: 
    git: 
      url: https://github.com/conghuy1992/image_downloader.git 
      ref: master
```
      
      flutter pub cache repair
