### PR TITLE
Fixed missing namespace in android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.ko2ic.imagedownloader"
+
     compileSdkVersion 33
 
     sourceSets {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.ko2ic.imagedownloader" />
+<manifest/>


### PR DESCRIPTION
Fixed the following problem:

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':image_downloader'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:
     
     android {
         namespace 'com.example.namespace'
     }
     
     If the package attribute is specified in the source AndroidManifest.xml, it can be migrated automatically to the namespace value in the build.gradle file using the AGP Upgrade Assistant; please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.